### PR TITLE
consistent-naming consistent types naming corresponds to OSRM API naming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ go:
   - "1.8"
   - "1.9"
   - "1.10"
+  - "1.11"
   - "tip"
 
 install:
   - go get -t -u ./...
+
+script: go test -run=Test* -v ./...

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ func main() {
 
 	resp, err := client.Route(ctx, osrm.RouteRequest{
 		Profile: "car",
-		GeoPath: *osrm.NewGeoPathFromPointSet(geo.PointSet{
+		Coordinates: osrm.NewGeometryFromPointSet(geo.PointSet{
 			{-73.980020, 40.751739},
 			{-73.962662, 40.794156},
 		}),

--- a/client_test.go
+++ b/client_test.go
@@ -27,7 +27,7 @@ func Test_doRequestWithBadHTTPCode(t *testing.T) {
 	c := newClient(ts.URL, &http.Client{})
 	req := request{
 		profile: "something",
-		geoPath: geoPath,
+		coords:  geometry,
 		service: "foobar",
 	}
 	err := c.doRequest(context.Background(), &req, nil)
@@ -43,7 +43,7 @@ func Test_doRequestWithBodyUnmarshalFailure(t *testing.T) {
 	c := newClient(ts.URL, &http.Client{})
 	req := request{
 		profile: "something",
-		geoPath: geoPath,
+		coords:  geometry,
 		service: "foobar",
 	}
 	err := c.doRequest(context.Background(), &req, nil)

--- a/examples_test.go
+++ b/examples_test.go
@@ -14,7 +14,7 @@ func ExampleOSRM_Route() {
 
 	resp, err := client.Route(context.Background(), osrm.RouteRequest{
 		Profile: "car",
-		GeoPath: *osrm.NewGeoPathFromPointSet(geo.PointSet{
+		Coordinates: osrm.NewGeometryFromPointSet(geo.PointSet{
 			{-73.87946, 40.75833},
 			{-73.87925, 40.75837},
 			{-73.87918, 40.75837},

--- a/match.go
+++ b/match.go
@@ -5,7 +5,7 @@ import geo "github.com/paulmach/go.geo"
 // MatchRequest represents a request to the match method
 type MatchRequest struct {
 	Profile     string
-	GeoPath     GeoPath
+	Coordinates Geometry
 	Steps       Steps
 	Annotations Annotations
 	Tidy        Tidy
@@ -19,8 +19,8 @@ type MatchRequest struct {
 
 // MatchResponse represents a response from the match method
 type MatchResponse struct {
-	Matchings   []Matching  `json:"matchings"`
-	Tracepoints []*Waypoint `json:"tracepoints"`
+	Matchings   []Matching    `json:"matchings"`
+	Tracepoints []*Tracepoint `json:"tracepoints"`
 }
 
 type matchResponseOrError struct {
@@ -31,8 +31,8 @@ type matchResponseOrError struct {
 // Matching represents an array of Route objects that assemble the trace
 type Matching struct {
 	Route
-	Confidence float64 `json:"confidence"`
-	Geometry   GeoPath `json:"geometry"`
+	Confidence float64  `json:"confidence"`
+	Geometry   Geometry `json:"geometry"`
 }
 
 func (r MatchRequest) request() *request {
@@ -53,7 +53,7 @@ func (r MatchRequest) request() *request {
 
 	return &request{
 		profile: r.Profile,
-		geoPath: r.GeoPath,
+		coords:  r.Coordinates,
 		service: "match",
 		options: options,
 	}
@@ -64,8 +64,8 @@ func (r MatchRequest) URL(serverURL string) (string, error) {
 	return r.request().URL(serverURL)
 }
 
-// Waypoint represents a matched point on a route
-type Waypoint struct {
+// Tracepoint represents a matched point on a route
+type Tracepoint struct {
 	Index             int       `json:"waypoint_index"`
 	Location          geo.Point `json:"location"`
 	MatchingIndex     int       `json:"matchings_index"`

--- a/nearest.go
+++ b/nearest.go
@@ -4,10 +4,10 @@ import geo "github.com/paulmach/go.geo"
 
 // NearestRequest represents a request to the nearest method
 type NearestRequest struct {
-	Profile  string
-	GeoPath  GeoPath
-	Bearings []Bearing
-	Number   int
+	Profile     string
+	Coordinates Geometry
+	Bearings    []Bearing
+	Number      int
 }
 
 // NearestResponse represents a response from the nearest method
@@ -42,7 +42,7 @@ func (r NearestRequest) request() *request {
 	return &request{
 		profile: r.Profile,
 		service: "nearest",
-		geoPath: r.GeoPath,
+		coords:  r.Coordinates,
 		options: opts,
 	}
 }

--- a/osrm_test.go
+++ b/osrm_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var geoPath = *NewGeoPathFromPointSet(
+var geometry = NewGeometryFromPointSet(
 	geo.PointSet([]geo.Point{
 		{-73.990185, 40.714701},
 		{-73.991801, 40.717571},
@@ -45,7 +45,7 @@ func TestErrorWithTimeout(t *testing.T) {
 	req := request{
 		service: "nothing",
 		profile: "nothing",
-		geoPath: geoPath,
+		coords:  geometry,
 	}
 
 	err := osrm.query(context.Background(), &req, nothing)
@@ -63,7 +63,7 @@ func TestErrorOnRouteRequest(t *testing.T) {
 
 	r, err := osrm.Route(context.Background(), RouteRequest{
 		Profile:          "car",
-		GeoPath:          geoPath,
+		Coordinates:      geometry,
 		Annotations:      AnnotationsFalse,
 		Steps:            StepsFalse,
 		Geometries:       GeometriesPolyline6,
@@ -88,7 +88,7 @@ func TestRouteRequest(t *testing.T) {
 
 	r, err := osrm.Route(context.Background(), RouteRequest{
 		Profile:          "car",
-		GeoPath:          geoPath,
+		Coordinates:      geometry,
 		Annotations:      AnnotationsTrue,
 		Geometries:       GeometriesPolyline6,
 		Overview:         OverviewFull,
@@ -122,7 +122,7 @@ func TestRouteRequest(t *testing.T) {
 	require.Equal("", step0.Name)
 	require.Equal(float32(5.0), step0.Duration)
 	require.Equal(float32(33.1), step0.Distance)
-	require.Equal(GeoPath{
+	require.Equal(Geometry{
 		Path: *geo.NewPathFromXYSlice([][]float64{
 			{-73.9902, 40.7147},
 			{-73.99023, 40.7146},
@@ -140,7 +140,7 @@ func TestTableRequest(t *testing.T) {
 
 	osrm := NewFromURL(ts.URL)
 
-	r, err := osrm.Table(context.Background(), TableRequest{Profile: "car", GeoPath: geoPath})
+	r, err := osrm.Table(context.Background(), TableRequest{Profile: "car", Coordinates: geometry})
 
 	require := require.New(t)
 
@@ -163,8 +163,8 @@ func TestMatchRequest(t *testing.T) {
 	osrm := NewFromURL(ts.URL)
 
 	r, err := osrm.Match(context.Background(), MatchRequest{
-		Profile: "car",
-		GeoPath: geoPath,
+		Profile:     "car",
+		Coordinates: geometry,
 	})
 
 	require := require.New(t)

--- a/route.go
+++ b/route.go
@@ -9,7 +9,7 @@ import (
 // RouteRequest represents a request to the route method
 type RouteRequest struct {
 	Profile          string
-	GeoPath          GeoPath
+	Coordinates      Geometry
 	Bearings         []Bearing
 	Steps            Steps
 	Annotations      Annotations
@@ -54,7 +54,7 @@ type RouteStep struct {
 	Distance float32      `json:"distance"`
 	Duration float32      `json:"duration"`
 	Name     string       `json:"name"`
-	Geometry GeoPath      `json:"geometry"`
+	Geometry Geometry     `json:"geometry"`
 	Mode     string       `json:"mode"`
 	Maneuver StepManeuver `json:"maneuver"`
 }
@@ -78,7 +78,7 @@ func (r RouteRequest) request() *request {
 
 	return &request{
 		profile: r.Profile,
-		geoPath: r.GeoPath,
+		coords:  r.Coordinates,
 		service: "route",
 		options: opts,
 	}

--- a/table.go
+++ b/table.go
@@ -3,7 +3,7 @@ package osrm
 // TableRequest represents a request to the table method
 type TableRequest struct {
 	Profile               string
-	GeoPath               GeoPath
+	Coordinates           Geometry
 	Sources, Destinations []int
 }
 
@@ -28,7 +28,7 @@ func (r TableRequest) request() *request {
 
 	return &request{
 		profile: r.Profile,
-		geoPath: r.GeoPath,
+		coords:  r.Coordinates,
 		service: "table",
 		options: opts,
 	}

--- a/types_test.go
+++ b/types_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnmarshalGeoPathFromPointsArray(t *testing.T) {
-	gp := GeoPath{}
+func TestUnmarshalGeometryFromPointsArray(t *testing.T) {
+	gp := Geometry{}
 	jdata := []byte("[[-73.982253,40.742926],[-73.985253,40.742926]]")
 
 	err := json.Unmarshal(jdata, &gp)
@@ -21,8 +21,8 @@ func TestUnmarshalGeoPathFromPointsArray(t *testing.T) {
 	require.Equal(t, *geo.NewPointFromLatLng(40.742926, -73.985253), gp.PointSet[1])
 }
 
-func TestUnmarshalGeoPathFromPolyline(t *testing.T) {
-	gp := GeoPath{}
+func TestUnmarshalGeometryFromPolyline(t *testing.T) {
+	gp := Geometry{}
 	jdata := []byte("\"w{_tlA`a_clCkrDldB~vBcyJ\"")
 
 	err := json.Unmarshal(jdata, &gp)
@@ -34,19 +34,19 @@ func TestUnmarshalGeoPathFromPolyline(t *testing.T) {
 	require.Equal(t, *geo.NewPointFromLatLng(40.71565, -73.98575), gp.PointSet[2])
 }
 
-func TestPolylineGeoPath(t *testing.T) {
+func TestPolylineGeometry(t *testing.T) {
 	path := geo.NewPath()
 	path.Push(geo.NewPointFromLatLng(40.714701, -73.990177))
 	path.Push(geo.NewPointFromLatLng(40.717572, -73.991801))
 	path.Push(geo.NewPointFromLatLng(40.715653, -73.985752))
-	gp := GeoPath{*path}
+	gp := Geometry{*path}
 	assert.Equal(t, "{aowFrerbM}PbI~Jyd@", gp.Polyline())
 }
 
 func TestRequestURLWithEmptyOptions(t *testing.T) {
 	req := request{
 		profile: "something",
-		geoPath: geoPath,
+		coords:  geometry,
 		service: "foobar",
 	}
 	url, err := req.URL("localhost")
@@ -59,7 +59,7 @@ func TestRequestURLWithOptions(t *testing.T) {
 	opts.set("baz", "quux")
 	req := request{
 		profile: "something",
-		geoPath: geoPath,
+		coords:  geometry,
 		service: "foobar",
 		options: opts,
 	}


### PR DESCRIPTION
`GeoPath type` renamed to `Geometry`
`GeoPath parameter` renamed to `Coordinates`
`Waypoint type` renamed to `Tracepoint`

It's a breaking change to the previous version. Be ready to update your integration. 