### PR TITLE
Support annotations for TableRequest

### DIFF
--- a/table.go
+++ b/table.go
@@ -5,6 +5,7 @@ type TableRequest struct {
 	Profile               string
 	Coordinates           Geometry
 	Sources, Destinations []int
+	Annotations           []string
 }
 
 // TableResponse resresents a response from the table method
@@ -20,6 +21,9 @@ func (r TableRequest) request() *request {
 	}
 	if len(r.Destinations) > 0 {
 		opts.addInt("destinations", r.Destinations...)
+	}
+	if len(r.Annotations) > 0 {
+		opts.add("annotations", r.Annotations...)
 	}
 
 	return &request{

--- a/table_test.go
+++ b/table_test.go
@@ -15,6 +15,7 @@ func TestNotEmptyTableRequestOptions(t *testing.T) {
 	req := TableRequest{
 		Sources:      []int{0, 1, 2},
 		Destinations: []int{1, 3},
+		Annotations:  []string{AnnotationsDuration.String(), AnnotationsDistance.String()},
 	}
-	assert.Equal(t, "destinations=1;3&sources=0;1;2", req.request().options.encode())
+	assert.Equal(t, "annotations=duration;distance&destinations=1;3&sources=0;1;2", req.request().options.encode())
 }


### PR DESCRIPTION
By default, OSRM's [Table Service](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/http.md#table-service) only returns duration. This PR adds support for specifying annotations so that distance can be returned, in addition duration.

Closes https://github.com/gojuno/go.osrm/issues/23